### PR TITLE
fix: Remove admin panel link from footer

### DIFF
--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -15,7 +15,6 @@ const Footer = () => {
           <a href="/contact">Contact</a>
           <a href="/about">About</a>
           <a href="/blog">Blog</a>
-          <a href="/update-instructors" style={{ color: '#e53e3e' }}>Admin</a>
         </div>
         <div className="footer-copyright">
           &copy; {new Date().getFullYear()} Reign Jiu Jitsu. All rights reserved.


### PR DESCRIPTION
This commit removes the publicly visible link to the `/update-instructors` admin panel from the site's footer. This is a security measure to ensure that the admin page is not easily discoverable by regular users. The page remains accessible by manually navigating to the URL.