### PR TITLE
fix: Resolve ESLint warnings to allow Vercel deployment

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -69,7 +69,7 @@ const AppLayout = () => {
     return () => {
       window.removeEventListener('scroll', handleScroll);
     };
-  }, [location.pathname]); // Re-run effect when the page route changes
+  }, [location.pathname, appClassName]); // Re-run effect when the page route changes or appClassName is updated
 
   return (
     <div className={`App ${appClassName}`}>

--- a/src/components/InstagramFeed.js
+++ b/src/components/InstagramFeed.js
@@ -16,7 +16,7 @@ const InstagramFeed = () => {
       <h2 className="section-title">Latest on Instagram</h2>
       <div className="instagram-grid">
         {instagramPosts.map(post => (
-          <a key={post.id} href="#" target="_blank" rel="noopener noreferrer" className="instagram-post-link">
+          <a key={post.id} href="https://www.instagram.com/" target="_blank" rel="noopener noreferrer" className="instagram-post-link">
             <img src={post.img} alt={`Instagram post ${post.id}`} />
           </a>
         ))}

--- a/src/components/WelcomeSection.js
+++ b/src/components/WelcomeSection.js
@@ -13,7 +13,7 @@ const WelcomeSection = () => {
           <div className="brush-separator"></div>
         </div>
         <div className="welcome-image-wrapper">
-          <img src="https://placehold.co/1200x450?text=Group+photo+of+students" alt="Group photo of mixed-age students" />
+          <img src="https://placehold.co/1200x450?text=Group+photo+of+students" alt="Group of mixed-age students on the mats" />
         </div>
       </div>
     </section>

--- a/src/pages/AdultProgram.js
+++ b/src/pages/AdultProgram.js
@@ -61,7 +61,7 @@ const AdultProgram = () => {
       </section>
 
       <div style={{'textAlign':'center', 'marginBottom': '60px'}}>
-        <img src="https://placehold.co/600x400?text=Group+Adult+Photo" alt="Group adult photo" />
+        <img src="https://placehold.co/600x400?text=Group+Adult+Photo" alt="Group of adult students after a jiu jitsu class" />
       </div>
 
       <FAQ faqData={pageFaqs} title="Adult Program FAQs" />


### PR DESCRIPTION
This commit addresses several ESLint warnings that were being treated as errors in the Vercel build environment, causing deployments to fail.

The following issues have been resolved:
- **`react-hooks/exhaustive-deps`:** Added the missing `appClassName` dependency to the `useEffect` hook in `src/App.js`.
- **`jsx-a11y/anchor-is-valid`:** Replaced an invalid `href="#"` with a valid URL in `src/components/InstagramFeed.js`.
- **`jsx-a11y/img-redundant-alt`:** Removed redundant words like "photo" from the alt text of images in `src/components/WelcomeSection.js` and `src/pages/AdultProgram.js` to improve accessibility.

These changes should allow the project to build and deploy successfully on Vercel.