### PR TITLE
fix: Remove unused `useRef` import from Navbar

### DIFF
--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import './Navbar.css';
 


### PR DESCRIPTION
This commit resolves the final Vercel build error, which was caused by an unused `useRef` import in the `Navbar.js` component.

Vercel's build process treats all ESLint warnings as errors, and this unused variable was causing the build to fail. Removing it allows the project to be deployed successfully.

This is the definitive fix for the recent deployment issues.